### PR TITLE
fix: prevent permanent isScrolling lock when tab is backgrounded

### DIFF
--- a/scripts/navigation.js
+++ b/scripts/navigation.js
@@ -582,6 +582,11 @@ const smoothScrollTo = (targetPosition) => {
     const distance = targetPosition - startPosition
     let startTime = null
 
+    // Safety fallback: ensure isScrolling is always reset even if rAF is suspended
+    const safetyTimeout = setTimeout(() => {
+        isScrolling = false
+    }, duration + 100)
+
     const animationStep = (currentTime) => {
         if (startTime === null) {
             startTime = currentTime
@@ -601,6 +606,7 @@ const smoothScrollTo = (targetPosition) => {
         if (elapsedTime < duration) {
             requestAnimationFrame(animationStep)
         } else {
+            clearTimeout(safetyTimeout)
             isScrolling = false
         }
     }


### PR DESCRIPTION
## Summary
- `smoothScrollTo` sets `isScrolling = true` at the start and only resets it inside a `requestAnimationFrame` callback, which is suspended when the user switches tabs — permanently locking navigation.
- Added a `setTimeout` safety fallback that forces `isScrolling = false` after `duration + 100` ms.
- On the normal animation-complete path, `clearTimeout` cancels the safety timer so there is no double-reset or race.

## Test plan
- [ ] `node --check scripts/navigation.js` passes (no syntax errors)
- [ ] Browser: navigate to a card, immediately switch tabs during the scroll animation, switch back — navigation should still work normally
- [ ] Browser: normal navigation (no tab switch) continues to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)