### PR TITLE
fix: replace 100vw with 100% in contact form mobile media query

### DIFF
--- a/styles/contact.scss
+++ b/styles/contact.scss
@@ -313,15 +313,15 @@
 @media only screen and (max-width: 480px) {
     .form-container {
         gap: 1rem;
-        width: 100vw;
-        max-width: 100vw;
+        width: 100%;
+        max-width: 100%;
         box-sizing: border-box;
         padding: 0 1rem;
 
         .contact-form {
             padding: 2rem;
-            width: 100vw;
-            max-width: 100vw;
+            width: 100%;
+            max-width: 100%;
             box-sizing: border-box;
 
             & input,


### PR DESCRIPTION
## Summary
- In the `@media only screen and (max-width: 480px)` block, `.form-container` and `.contact-form` were using `width: 100vw; max-width: 100vw`
- `100vw` includes the scrollbar width on devices that show scrollbars, causing horizontal overflow and an unwanted horizontal scrollbar on mobile
- Changed both selectors to `width: 100%; max-width: 100%; box-sizing: border-box` which respects the parent's available space correctly

## Test plan
- [x] `pnpm run css` compiles without errors (only pre-existing `@import` deprecation warnings)
- [ ] Browser verification: confirm no horizontal scrollbar on mobile viewports at ≤480px on the contact page

🤖 Generated with [Claude Code](https://claude.com/claude-code)