### PR TITLE
fix: make modal position fixed and scrollable at all breakpoints

### DIFF
--- a/styles/modal.scss
+++ b/styles/modal.scss
@@ -1,9 +1,12 @@
 .modal {
-    position: absolute;
+    position: fixed;
     top: 0;
     left: 0;
     width: 100%;
     height: 100%;
+    max-height: 100dvh;
+    overflow-y: auto;
+    overscroll-behavior: contain;
     background-color: transparent;
     z-index: 1000;
     transition: all var(--transition-duration-fast) ease-in-out;
@@ -119,8 +122,6 @@
 
 @media (max-width: 600px) {
     .modal {
-        overflow-y: auto;
-
         .modal-header {
             .modal-title-container {
                 margin-left: 0;


### PR DESCRIPTION
## Summary
- Change `.modal` `position` from `absolute` to `fixed` so it correctly overlays the viewport when `html`/`body` are `position: fixed`
- Add `max-height: 100dvh` and `overflow-y: auto` at the base `.modal` level so content scrolls on desktop/tablet as well as mobile
- Add `overscroll-behavior: contain` to prevent scroll events from bubbling out to the card navigation when the modal is scrolled
- Remove the now-redundant `overflow-y: auto` from the `@media (max-width: 600px)` block

## Test plan
- [ ] Open a project card to trigger the modal
- [ ] Confirm the modal overlays the full viewport correctly
- [ ] Scroll within the modal on desktop — content should scroll without triggering card navigation
- [ ] Scroll within the modal on mobile (≤ 600px) — same behaviour
- [ ] Close the modal and verify card navigation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)