### PR TITLE
fix: rationalize z-index scale and restore pinch-zoom on mobile

### DIFF
--- a/styles/shared.scss
+++ b/styles/shared.scss
@@ -7,7 +7,7 @@ html, body {
   position: fixed;
   overflow: hidden !important;
   overscroll-behavior: none;
-  touch-action: none;
+  touch-action: pan-x pan-y;
 }
 
 body {
@@ -62,7 +62,7 @@ footer {
     color: var(--primary-color);
     cursor: pointer;
     font-weight: bold;
-    z-index: 100;
+    z-index: 10;
     text-align: center;
     width: auto;
     min-width: 3rem;
@@ -185,7 +185,7 @@ footer {
         flex-direction: column;
         align-items: center;
         justify-content: center;
-        z-index: 9999;
+        z-index: 30;
     }
     .chev-section {
         display: none !important;
@@ -220,7 +220,7 @@ footer {
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 1000;
+    z-index: 20;
     opacity: 0;
     visibility: hidden;
     transition: opacity 0.3s ease-in-out, visibility 0.3s ease-in-out;
@@ -263,7 +263,7 @@ footer {
     background-color: rgba(0, 0, 0, 0.5);
     border: 1px solid rgba(255, 255, 255, 0.8);
     border-radius: 1rem / 2rem;
-    z-index: 1000;
+    z-index: 20;
     display: flex;
     justify-content: center;
     box-shadow: 0 0 5px rgba(0, 0, 0, 0.3);


### PR DESCRIPTION
## Summary
- Replace `touch-action: none` with `touch-action: pan-x pan-y` on `html, body` to restore pinch-to-zoom accessibility on mobile while preserving custom JS swipe handling
- Normalize z-index values in `shared.scss` to a coherent scale: `.chev` desktop → 10, `#pill-indicator` and `#scroll-indicator` → 20, `.chev` mobile → 30 (was 100, 1000, 1000, 9999 respectively)

## Test plan
- [ ] Compile SCSS with `pnpm run css` — no errors (only pre-existing `@import` deprecation warnings)
- [ ] Verify pinch-to-zoom works on mobile after the touch-action change
- [ ] Verify navigation chevrons, pill indicator, and scroll indicator render correctly at their new stacking levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)